### PR TITLE
Add Attachment and Complex Character Positioning

### DIFF
--- a/src/editor/editor.c
+++ b/src/editor/editor.c
@@ -1190,6 +1190,14 @@ text_editor_split_at_mark (TextEditor *self,
             iter = next;
         }
 
+        // Ensure the original paragraph has at least one run (all runs may be
+        // moved when the split index is at the start of the paragraph)
+        if (text_node_get_num_children (TEXT_PARAGRAPH (current)) == 0)
+        {
+            // Add empty run
+            text_paragraph_append_run(current, text_run_new(""));
+        }
+
         // Append paragraph to document tree
         parent = text_node_get_parent (TEXT_NODE (current));
         text_node_insert_child_after (parent, TEXT_NODE (new), TEXT_NODE (current));
@@ -1209,7 +1217,7 @@ text_editor_split_at_mark (TextEditor *self,
 
         // Mark is on split point
         if (mark->paragraph == current &&
-              mark->index == split->index)
+            mark->index == split->index)
         {
             _distribute_mark (mark, current, split->index, new, 0);
             continue;

--- a/src/layout/layout-box.c
+++ b/src/layout/layout-box.c
@@ -97,7 +97,9 @@ text_layout_box_set_property (GObject      *object,
 void
 text_layout_box_layout (TextLayoutBox *self,
                         PangoContext  *context,
-                        int            width)
+                        int            width,
+                        int            offset_x,
+                        int            offset_y)
 {
     g_return_if_fail (TEXT_IS_LAYOUT_BOX (self));
 
@@ -164,8 +166,8 @@ text_layout_box_layout (TextLayoutBox *self,
         g_debug (" - Child height %d\n", height);
     }
 
-    priv->bbox.x = 0;
-    priv->bbox.y = 0;
+    priv->bbox.x = offset_x;
+    priv->bbox.y = offset_y;
     priv->bbox.width = width;
     priv->bbox.height = height;
 }

--- a/src/layout/layout-box.h
+++ b/src/layout/layout-box.h
@@ -42,7 +42,9 @@ text_layout_box_get_item (TextLayoutBox *self);
 void
 text_layout_box_layout (TextLayoutBox *self,
                         PangoContext  *context,
-                        int            width);
+                        int            width,
+                        int            offset_x,
+                        int            offset_y);
 
 const TextDimensions *
 text_layout_box_get_bbox (TextLayoutBox *self);

--- a/src/layout/layout.c
+++ b/src/layout/layout.c
@@ -139,6 +139,46 @@ text_layout_build_layout_tree (TextLayout   *self,
     return root;
 }
 
+TextLayoutBox *
+text_layout_pick (TextLayoutBox *root,
+                  int            x,
+                  int            y)
+{
+    // Note: 'x' and 'y' are relative to the document origin
+    TextNode *child;
+    TextNode *found;
+
+    g_return_val_if_fail (TEXT_IS_LAYOUT_BOX (root), NULL);
+
+    for (child = text_node_get_first_child (TEXT_NODE (root));
+         child != NULL;
+         child = text_node_get_next (child))
+    {
+        TextLayoutBox *layout_item;
+        TextDimensions *bbox;
+
+        layout_item = TEXT_LAYOUT_BOX (child);
+        bbox = text_layout_box_get_bbox (layout_item);
+
+        if (x >= bbox->x &&
+            y >= bbox->y &&
+            x <= bbox->x + bbox->width &&
+            y <= bbox->y + bbox->height)
+        {
+            // Recursively check child layouts first
+            found = text_layout_pick (layout_item, x, y);
+
+            if (found) {
+                return found;
+            }
+
+            return layout_item;
+        }
+    }
+
+    return NULL;
+}
+
 static void
 text_layout_class_init (TextLayoutClass *klass)
 {

--- a/src/layout/layout.c
+++ b/src/layout/layout.c
@@ -136,6 +136,18 @@ text_layout_build_layout_tree (TextLayout   *self,
 }
 
 TextLayoutBox *
+text_layout_find_above (TextLayoutBox *item)
+{
+    return TEXT_LAYOUT_BOX (text_node_get_previous (TEXT_LAYOUT_BOX (item)));
+}
+
+TextLayoutBox *
+text_layout_find_below (TextLayoutBox *item)
+{
+    return TEXT_LAYOUT_BOX (text_node_get_next (TEXT_LAYOUT_BOX (item)));
+}
+
+TextLayoutBox *
 text_layout_pick_internal (TextLayoutBox *root,
                            int            x,
                            int            y,

--- a/src/layout/layout.c
+++ b/src/layout/layout.c
@@ -73,7 +73,6 @@ static void
 do_layout_recursive (TextLayout    *self,
                      TextLayoutBox *parent,
                      PangoContext  *context,
-                     TextMark      *cursor,
                      TextItem      *item,
                      int            width)
 {
@@ -106,16 +105,6 @@ do_layout_recursive (TextLayout    *self,
             text_item_detach (TEXT_ITEM (node)); // TODO: Don't do this
             text_item_attach (TEXT_ITEM (node), TEXT_NODE (box));
 
-            // TODO: We should handle runs inline here, rather than
-            // paragraphs. As we do not consider individual runs, we
-            // must check whether the paragraph contains a cursor and
-            // then handle layout for the cursor object.
-            if (TEXT_PARAGRAPH (node) == cursor->paragraph)
-            {
-                // Paragraph contains cursor
-                text_layout_box_set_cursor (box, cursor->index);
-            }
-
             text_node_append_child (TEXT_NODE (parent), TEXT_NODE (box));
             g_debug ("Added child %s\n", g_type_name_from_instance (node));
 
@@ -135,7 +124,6 @@ do_layout_recursive (TextLayout    *self,
 TextLayoutBox *
 text_layout_build_layout_tree (TextLayout   *self,
                                PangoContext *context,
-                               TextMark     *cursor,
                                TextFrame    *frame,
                                int           width)
 {
@@ -143,7 +131,7 @@ text_layout_build_layout_tree (TextLayout   *self,
     g_return_val_if_fail (TEXT_IS_FRAME (frame), NULL);
 
     TextLayoutBox *root = text_layout_box_new ();
-    do_layout_recursive (self, root, context, cursor, TEXT_ITEM (frame), width);
+    do_layout_recursive (self, root, context, TEXT_ITEM (frame), width);
     return root;
 }
 

--- a/src/layout/layout.c
+++ b/src/layout/layout.c
@@ -97,6 +97,8 @@ do_layout_recursive (TextLayout    *self,
         {
             TextLayoutBox *box = text_layout_box_new ();
             text_layout_box_set_item (box, TEXT_ITEM (node));
+            text_item_detach (TEXT_ITEM (node)); // TODO: Don't do this
+            text_item_attach (TEXT_ITEM (node), TEXT_NODE (box));
 
             // TODO: We should handle runs inline here, rather than
             // paragraphs. As we do not consider individual runs, we

--- a/src/layout/layout.h
+++ b/src/layout/layout.h
@@ -32,7 +32,6 @@ TextLayout *text_layout_new (void);
 TextLayoutBox *
 text_layout_build_layout_tree (TextLayout   *self,
                                PangoContext *context,
-                               TextMark     *cursor,
                                TextFrame    *frame,
                                int           width);
 

--- a/src/layout/layout.h
+++ b/src/layout/layout.h
@@ -36,4 +36,9 @@ text_layout_build_layout_tree (TextLayout   *self,
                                TextFrame    *frame,
                                int           width);
 
+TextLayoutBox *
+text_layout_pick (TextLayoutBox *root,
+                  int            x,
+                  int            y);
+
 G_END_DECLS

--- a/src/layout/layout.h
+++ b/src/layout/layout.h
@@ -40,4 +40,10 @@ text_layout_pick (TextLayoutBox *root,
                   int            x,
                   int            y);
 
+TextLayoutBox *
+text_layout_find_above (TextLayoutBox *item);
+
+TextLayoutBox *
+text_layout_find_below (TextLayoutBox *item);
+
 G_END_DECLS

--- a/src/model/item.c
+++ b/src/model/item.c
@@ -11,7 +11,12 @@
 
 #include "item.h"
 
-G_DEFINE_TYPE (TextItem, text_item, TEXT_TYPE_NODE)
+typedef struct
+{
+    TextNode *renderer;
+} TextItemPrivate;
+
+G_DEFINE_TYPE_WITH_PRIVATE (TextItem, text_item, TEXT_TYPE_NODE)
 
 enum {
     PROP_0,
@@ -31,6 +36,32 @@ TextItem *
 text_item_new (void)
 {
     return g_object_new (TEXT_TYPE_ITEM, NULL);
+}
+
+void
+text_item_attach (TextItem *self,
+                  TextNode *attachment)
+{
+    TextItemPrivate *priv = text_item_get_instance_private (self);
+
+    g_return_if_fail (!priv->renderer);
+
+    priv->renderer = g_object_ref (attachment);
+}
+
+TextNode *
+text_item_get_attachment (TextItem *self)
+{
+    TextItemPrivate *priv = text_item_get_instance_private (self);
+    return TEXT_NODE (priv->renderer);
+}
+
+void
+text_item_detach (TextItem *self)
+{
+    TextItemPrivate *priv = text_item_get_instance_private (self);
+    if (priv->renderer)
+        g_clear_object (&priv->renderer);
 }
 
 static void

--- a/src/model/item.h
+++ b/src/model/item.h
@@ -27,4 +27,13 @@ struct _TextItemClass
 
 TextItem *text_item_new (void);
 
+void
+text_item_attach (TextItem *self,
+                  TextNode *attachment);
+TextNode *
+text_item_get_attachment (TextItem *self);
+
+void
+text_item_detach (TextItem *self);
+
 G_END_DECLS

--- a/src/ui/display.c
+++ b/src/ui/display.c
@@ -758,14 +758,16 @@ pointer_pressed (GtkGestureClick *gesture,
 
     if (self->layout_tree) {
         TextLayoutBox *box;
-        TextItem *item;
 
         // TODO: Account for scrolling
         box = text_layout_pick (self->layout_tree, x - self->margin_start, y - self->margin_top);
 
         if (box) {
-            g_print ("Found!\n");
+            TextItem *item;
+            TextDimensions *bbox;
+
             item = text_layout_box_get_item (box);
+            bbox = text_layout_box_get_bbox (box);
 
             // TODO: Properly find the nearest leaf node
             // when we have more complex renderers
@@ -773,8 +775,8 @@ pointer_pressed (GtkGestureClick *gesture,
 
             int index, trailing;
             if (pango_layout_xy_to_index (text_layout_box_get_pango_layout (box),
-                                          (x - self->margin_start) * PANGO_SCALE,
-                                          (y - self->margin_top) * PANGO_SCALE,
+                                          (x - bbox->x - self->margin_start) * PANGO_SCALE,
+                                          (y - bbox->y - self->margin_top) * PANGO_SCALE,
                                           &index, &trailing))
             {
                 self->document->cursor->paragraph = TEXT_PARAGRAPH (item);

--- a/src/ui/display.c
+++ b/src/ui/display.c
@@ -572,8 +572,6 @@ key_pressed (GtkEventControllerKey *controller,
             para = self->document->cursor->paragraph;
             layout = TEXT_LAYOUT_BOX (text_item_get_attachment (TEXT_ITEM (para)));
 
-            g_print ("Index: %d\n", index);
-
             if (layout) {
                 PangoLayout *pango;
                 GSList *iter;
@@ -590,8 +588,6 @@ key_pressed (GtkEventControllerKey *controller,
 
                     is_last_line = (iter->next == NULL);
                     line = iter->data;
-
-                    g_print ("Base Index: %d\n", base_index);
 
                     // For the last line in the paragraph, there is an imaginary 'paragraph break'
                     // character to account for the traversal between paragraphs. Therefore we check
@@ -629,8 +625,6 @@ key_pressed (GtkEventControllerKey *controller,
             para = self->document->cursor->paragraph;
             layout = TEXT_LAYOUT_BOX (text_item_get_attachment (TEXT_ITEM (para)));
 
-            g_print ("Index: %d\n", index);
-
             if (layout) {
                 PangoLayout *pango;
                 GSList *iter;
@@ -647,8 +641,6 @@ key_pressed (GtkEventControllerKey *controller,
                     
                     line = iter->data;
                     is_last_line = (iter->next == NULL);
-
-                    g_print ("Base Index: %d\n", base_index + pango_layout_line_get_length (line));
 
                     // For the last line in the paragraph, there is an imaginary 'paragraph break'
                     // character to account for the traversal between paragraphs. Therefore we check

--- a/src/ui/display.c
+++ b/src/ui/display.c
@@ -634,7 +634,18 @@ key_pressed (GtkEventControllerKey *controller,
                     g_print ("Length: %d\n", length + pango_layout_line_get_length (line));
 
                     if (index >= length && index < length + pango_layout_line_get_length (line)) {
-                        self->document->cursor->index = length + pango_layout_line_get_length (line);
+
+                        gboolean is_last_line;
+
+                        is_last_line = (iter->next == NULL);
+                        
+                        // Use the index position immediately before the final character in the line
+                        // when jumping to the end. For the final line, we pretend there is an imaginary
+                        // 'paragraph break' character, so the final index will be one greater.
+                        self->document->cursor->index = is_last_line
+                            ? length + pango_layout_line_get_length (line)
+                            : length + pango_layout_line_get_length (line) - 1;
+                        
                         goto handled;
                     }
 

--- a/src/ui/display.c
+++ b/src/ui/display.c
@@ -559,15 +559,89 @@ key_pressed (GtkEventControllerKey *controller,
     }
 
     // Handle Home/End
-    if (ctrl_pressed && keyval == GDK_KEY_Home)
+    if (keyval == GDK_KEY_Home)
     {
-        text_editor_move_first (self->editor, shift_pressed ? TEXT_EDITOR_SELECTION : TEXT_EDITOR_CURSOR);
+        if (ctrl_pressed)
+            text_editor_move_first (self->editor, shift_pressed ? TEXT_EDITOR_SELECTION : TEXT_EDITOR_CURSOR);
+        else {
+            TextParagraph *para;
+            TextLayoutBox *layout;
+            int index;
+
+            index = self->document->cursor->index;
+            para = self->document->cursor->paragraph;
+            layout = TEXT_LAYOUT_BOX (text_item_get_attachment (TEXT_ITEM (para)));
+
+            g_print ("Index: %d\n", index);
+
+            if (layout) {
+                PangoLayout *pango;
+                GSList *iter;
+                pango = text_layout_box_get_pango_layout (layout);
+                iter = pango_layout_get_lines (pango);
+                int length = 0;
+
+                for (iter = pango_layout_get_lines (pango);
+                     iter != NULL;
+                     iter = iter->next)
+                {
+                    PangoLayoutLine *line;
+                    line = iter->data;
+
+                    g_print ("Length: %d\n", length);
+
+                    if (length + pango_layout_line_get_length (line) >= index) {
+                        self->document->cursor->index = length;
+                        goto handled;
+                    }
+
+                    length += pango_layout_line_get_length (line);
+                }
+            }
+        }
         goto handled;
     }
 
-    if (ctrl_pressed && keyval == GDK_KEY_End)
+    if (keyval == GDK_KEY_End)
     {
-        text_editor_move_last (self->editor, shift_pressed ? TEXT_EDITOR_SELECTION : TEXT_EDITOR_CURSOR);
+        if (ctrl_pressed)
+            text_editor_move_last (self->editor, shift_pressed ? TEXT_EDITOR_SELECTION : TEXT_EDITOR_CURSOR);
+        else {
+            TextParagraph *para;
+            TextLayoutBox *layout;
+            int index;
+
+            index = self->document->cursor->index;
+            para = self->document->cursor->paragraph;
+            layout = TEXT_LAYOUT_BOX (text_item_get_attachment (TEXT_ITEM (para)));
+
+            g_print ("Index: %d\n", index);
+
+            if (layout) {
+                PangoLayout *pango;
+                GSList *iter;
+                pango = text_layout_box_get_pango_layout (layout);
+                iter = pango_layout_get_lines (pango);
+                int length = 0;
+
+                for (iter = pango_layout_get_lines (pango);
+                     iter != NULL;
+                     iter = iter->next)
+                {
+                    PangoLayoutLine *line;
+                    line = iter->data;
+
+                    g_print ("Length: %d\n", length + pango_layout_line_get_length (line));
+
+                    if (index >= length && index < length + pango_layout_line_get_length (line)) {
+                        self->document->cursor->index = length + pango_layout_line_get_length (line);
+                        goto handled;
+                    }
+
+                    length += pango_layout_line_get_length (line);
+                }
+            }
+        }
         goto handled;
     }
 
@@ -582,6 +656,34 @@ key_pressed (GtkEventControllerKey *controller,
     if (keyval == GDK_KEY_Right)
     {
         text_editor_move_right (self->editor, shift_pressed ? TEXT_EDITOR_SELECTION : TEXT_EDITOR_CURSOR, 1);
+        goto handled;
+    }
+
+    if (keyval == GDK_KEY_Up)
+    {
+        TextParagraph *para;
+        TextLayoutBox *layout;
+        int index;
+
+        index = self->document->cursor->index;
+        para = self->document->cursor->paragraph;
+        layout = TEXT_LAYOUT_BOX (text_item_get_attachment (TEXT_ITEM (para)));
+
+        g_print ("Up!\n");
+        goto handled;
+    }
+
+    if (keyval == GDK_KEY_Down)
+    {
+        TextParagraph *para;
+        TextLayoutBox *layout;
+        int index;
+
+        index = self->document->cursor->index;
+        para = self->document->cursor->paragraph;
+        layout = TEXT_LAYOUT_BOX (text_item_get_attachment (TEXT_ITEM (para)));
+
+        g_print ("Down!\n");
         goto handled;
     }
 

--- a/src/ui/display.c
+++ b/src/ui/display.c
@@ -754,6 +754,35 @@ pointer_pressed (GtkGestureClick *gesture,
                  gdouble          y,
                  TextDisplay     *self)
 {
+    g_print ("X: %lf Y: %lf\n", x, y);
+
+    if (self->layout_tree) {
+        TextLayoutBox *box;
+        TextItem *item;
+
+        // TODO: Account for scrolling
+        box = text_layout_pick (self->layout_tree, x - self->margin_start, y - self->margin_top);
+
+        if (box) {
+            g_print ("Found!\n");
+            item = text_layout_box_get_item (box);
+
+            // TODO: Properly find the nearest leaf node
+            // when we have more complex renderers
+            g_return_if_fail (TEXT_IS_PARAGRAPH (item));
+
+            int index, trailing;
+            if (pango_layout_xy_to_index (text_layout_box_get_pango_layout (box),
+                                          (x - self->margin_start) * PANGO_SCALE,
+                                          (y - self->margin_top) * PANGO_SCALE,
+                                          &index, &trailing))
+            {
+                self->document->cursor->paragraph = TEXT_PARAGRAPH (item);
+                self->document->cursor->index = index;
+            }
+        }
+    }
+
     gtk_widget_grab_focus (GTK_WIDGET (self));
     gtk_widget_queue_draw (GTK_WIDGET (self));
 }

--- a/src/ui/display.c
+++ b/src/ui/display.c
@@ -544,6 +544,7 @@ commit (GtkIMContext *context,
     // then bubbles up and invalidates the style
     // which then bubbles up and invalidates the layout
     // which then causes a partial redraw - simple right?
+    gtk_widget_queue_allocate (GTK_WIDGET (self));
     gtk_widget_queue_draw (GTK_WIDGET (self));
 
     g_print ("commit: %s\n", str);

--- a/src/ui/display.c
+++ b/src/ui/display.c
@@ -799,7 +799,7 @@ pointer_pressed (GtkGestureClick *gesture,
                  gdouble          y,
                  TextDisplay     *self)
 {
-    g_print ("X: %lf Y: %lf\n", x, y);
+    // g_print ("X: %lf Y: %lf\n", x, y);
 
     if (self->layout_tree) {
         TextLayoutBox *box;
@@ -809,7 +809,7 @@ pointer_pressed (GtkGestureClick *gesture,
 
         if (box) {
             TextItem *item;
-            TextDimensions *bbox;
+            const TextDimensions *bbox;
 
             item = text_layout_box_get_item (box);
             bbox = text_layout_box_get_bbox (box);
@@ -819,14 +819,15 @@ pointer_pressed (GtkGestureClick *gesture,
             g_return_if_fail (TEXT_IS_PARAGRAPH (item));
 
             int index, trailing;
-            if (pango_layout_xy_to_index (text_layout_box_get_pango_layout (box),
-                                          (x - bbox->x - self->margin_start) * PANGO_SCALE,
-                                          (y - bbox->y - self->margin_top) * PANGO_SCALE,
-                                          &index, &trailing))
-            {
-                self->document->cursor->paragraph = TEXT_PARAGRAPH (item);
-                self->document->cursor->index = index;
-            }
+
+            // Pango automatically clamps the coordinates to the layout for us
+            pango_layout_xy_to_index (text_layout_box_get_pango_layout (box),
+                                          (x - bbox->x) * PANGO_SCALE,
+                                          (y - bbox->y) * PANGO_SCALE,
+                                          &index, &trailing);
+
+            self->document->cursor->paragraph = TEXT_PARAGRAPH (item);
+            self->document->cursor->index = index;
         }
     }
 


### PR DESCRIPTION
 - Adds 'attachment' - this is a term borrowed from webkit to describe the process of attaching semantic model nodes to view-specific layout nodes.
 - Implements home and end line traversal according to #17 
 - Implements mouse-based picking for determining index under mouse position

TODO
 - [x] Add up/down movement
 - [x] Add cursor selection
 - [x] ~~Add unit tests for home/end~~ Deferred until traversal is separated from view
 - [x] Issues:
     - [x] Fix issue with splitting then entering at the start of the paragraph
     - [x] ~~Cannot select final index in paragraph with mouse~~ Pango issue, deferred until resolution on use of paragraph break characters
 - [x] Clean up:
     - [X] Rework cursor drawing to only reallocate when necessary
     - [X] Use fuzzy cursor picking (i.e. choose nearest when no exact match is found)
     - [x] Up/down within paragraphs

